### PR TITLE
Add education-and-self-care code to BeMedicationRequestReimbursementType

### DIFF
--- a/input/fsh/codesystems/BeMedicationRequestReimbursementType.fsh
+++ b/input/fsh/codesystems/BeMedicationRequestReimbursementType.fsh
@@ -66,8 +66,8 @@ Description: "Medication request reimbursement type - instructions for reimburse
   * ^designation[=].value = "Trajet de démarrage diabète type 2"
   * ^designation[+].language = #nl-BE
   * ^designation[=].value = "Opstarttraject diabetes type 2"
-* #education-and-self-care-program-type-2-diabetes "Program \"Education and self-care\" type 2 diabetes"
+* #education-and-self-care-program-type-2-diabetes "\"Education and self-care\" programme for type 2 diabetes"
   * ^designation[0].language = #fr-BE
-  * ^designation[=].value = "Programme \"Éducation et autosoins\" diabète type 2"
+  * ^designation[=].value = "Programme « Éducation et autogestion » pour le diabète de type 2"
   * ^designation[+].language = #nl-BE
   * ^designation[=].value = "Programma \"Educatie en zelfzorg\" diabetes type 2"

--- a/input/fsh/codesystems/BeMedicationRequestReimbursementType.fsh
+++ b/input/fsh/codesystems/BeMedicationRequestReimbursementType.fsh
@@ -20,7 +20,7 @@ Description: "Medication request reimbursement type - instructions for reimburse
 * ^jurisdiction = urn:iso:std:iso:3166#BE "Belgium"
 * ^caseSensitive = true
 * ^content = #complete
-* ^count = 9
+* ^count = 10
 * #third-party-payer-applicable "Third-party payer applicable"
   * ^designation[0].language = #fr-BE
   * ^designation[=].value = "Tiers-payant applicable"
@@ -66,3 +66,8 @@ Description: "Medication request reimbursement type - instructions for reimburse
   * ^designation[=].value = "Trajet de démarrage diabète type 2"
   * ^designation[+].language = #nl-BE
   * ^designation[=].value = "Opstarttraject diabetes type 2"
+* #education-and-self-care-program-type-2-diabetes "Program \"Education and self-care\" type 2 diabetes"
+  * ^designation[0].language = #fr-BE
+  * ^designation[=].value = "Programme \"Éducation et autosoins\" diabète type 2"
+  * ^designation[+].language = #nl-BE
+  * ^designation[=].value = "Programma \"Educatie en zelfzorg\" diabetes type 2"


### PR DESCRIPTION
## Context
During discussions with business stakeholders, we identified an additional reimbursement instruction value that needs to be supported. This PR adds the "Education and self-care" programme for type 2 diabetes to `BeMedicationRequestReimbursementTypeVS`, bringing the total from 9 to 10 possible values.

## Change
Adds the following concept to `input/fsh/valuesets/BeMedicationRequestReimbursementTypeVS.fsh`:

| Language | Display |
|----------|---------|
| NL | Programma "Educatie en zelfzorg" diabetes type 2 |
| FR | Programme « Éducation et autogestion » pour le diabète de type 2 |
| EN | "Education and self-care" programme for type 2 diabetes |

## Complete value set after this change
1. Third-party payment scheme applies
2. 1st administration
3. 2nd administration + [date of 1st administration]
4. 3rd administration + [date of 1st and 2nd administration]
5. Chronic renal failure care pathway
6. Diabetes care pathway
7. Diabetes convention
8. Not reimbursable
9. Type 2 diabetes induction pathway
10. **"Education and self-care" programme for type 2 diabetes** *(new)*