### PR TITLE
Add terminology narrative pages

### DIFF
--- a/input/pagecontent/authoring.md
+++ b/input/pagecontent/authoring.md
@@ -1,0 +1,55 @@
+**Authoring** is the role that *creates and maintains* terminology — deciding what a code means, giving each system a stable identity, and keeping it correct over time. It is deliberately separate from [deployment](dependencies.html) (making content resolvable) and [consumption](usage.html) (using it): defining a concept here does not by itself make it available to a running system.
+
+This page describes **what authoring produces** and **how to request changes** — including the upstream requests that some changes trigger.
+
+### What authoring produces
+
+The outcome of authoring is a set of FHIR terminology resources. Each answers a different question (see [Terminology Considerations](terminology.html) for the concepts):
+
+| Outcome | What it is | Authored when you need to… |
+|---------|------------|----------------------------|
+| **CodeSystem** | A set of concepts with their meaning and display | …define codes this jurisdiction owns (e.g. `BeCSVaccineCode`, `MyCareNet*`) |
+| **ValueSet** | A selection of codes for a particular use | …say which codes are allowed in a given element (e.g. `BeAllergyIntoleranceCode`) |
+| **ConceptMap / translations** | Correspondences between systems, and concept **translations** (designations in other languages) | …map between two systems, or provide FR/NL/DE display text for concepts |
+| **NamingSystem** | The canonical identity (URI + OID) of a code **or** identifier system | …declare *which URI* identifies a system (e.g. `be-ns-cnk-codes` for CNK) |
+
+Two notes specific to this IG:
+
+- **Translations are an authoring outcome too.** A "translation" can mean a *language* designation on a concept (e.g. an NL/FR/DE display), or a *ConceptMap* between two code systems. Both are produced by authoring, and both may involve upstream owners (see below).
+- **CodeSystem ≠ NamingSystem.** A CodeSystem defines *concepts*; a NamingSystem only declares *identity*. Many `be-ns-*` outputs are NamingSystems for **identifier** systems (CNK, SSIN, CBE, NIHDI), used to populate `Identifier.system` — not to validate codes.
+
+### How the content is authored
+
+The terminology here is authored in **FHIR Shorthand (FSH)** under `input/fsh/` and compiled by SUSHI:
+
+- `input/fsh/codesystems/` — CodeSystem definitions
+- `input/fsh/valuesets/` — ValueSet definitions
+- `input/fsh/instances/` — NamingSystem definitions (the `be-ns-*` resources) and other instances
+
+Authoring in FSH keeps definitions diffable, reviewable and version-controlled — which is what governance of a terminology actually requires. Each resource gets a stable **canonical URL** under `https://www.ehealth.fgov.be/standards/fhir/...` and a **version** that is bumped when the content changes in a way consumers should notice. Canonical URLs and meanings must never be repurposed: consumers pin to them.
+
+### Requesting changes
+
+Changes are **not** made by editing the files directly unless you are a maintainer. Instead, **raise a ticket** with the terminology owner (eHealth Platform / HL7 Belgium) via the FHIR support channel:
+
+- Issue tracker / support: **support@be-ehealth-standards.atlassian.net**
+- Project: <https://www.ehealth.fgov.be/standards/fhir>
+
+A ticket should say *what* you need (a new code, a corrected display, a new translation, a new value set or a new mapping), *where* it is used, and *why*. The owner then triages it and, where the content is **IG-owned** (the `BeCS*` / `MyCareNet*` systems and the `be-ns-*` naming systems), implements it directly and publishes a new version.
+
+### Tickets that launch upstream requests
+
+Many requests cannot be resolved inside this IG, because the underlying system is **owned elsewhere**. In those cases a single ticket *launches the necessary upstream request* and is tracked until the upstream owner delivers:
+
+| Request | Upstream owner | What the ticket triggers |
+|---------|----------------|--------------------------|
+| **New / changed SNOMED CT code** | SNOMED CT National Release Centre (Belgium) → SNOMED International | A request for new content in the Belgian or International edition; the code becomes usable only once published in a release loaded on the [terminology server](dependencies.html). |
+| **New SNOMED CT translation** (NL/FR/DE designations) | National Release Centre / translation programme | A translation request added to a future national release. |
+| **New / changed LOINC code** | Regenstrief (LOINC committee) | A LOINC submission; available after the next LOINC release. |
+| **External value set or mapping** | The relevant standard / domain owner | A request routed to that owner. |
+
+Because these systems live on a server and not in a package, the requested content only becomes available to implementers **after** the upstream release is published *and* loaded onto the terminology server — it is not delivered by re-publishing this IG. This is the practical reason external systems always require a server (see [Using terminology](usage.html#the-decision-rule-versioned-vs-unversioned)).
+
+### Governance and ownership
+
+Terminology is only as trustworthy as its governance: a code's meaning, its lifecycle (active / deprecated / retired) and its ownership must be clear and maintained. **This is the gap called out on the [home page](index.html)** — the current collection lacks the ownership and governance arrangements production terminology requires, which is why it is marked *not to be used* as-is. Putting that governance in place is the central authoring-side task.

--- a/input/pagecontent/dependencies.md
+++ b/input/pagecontent/dependencies.md
@@ -1,0 +1,42 @@
+This page covers the **deployment / distribution** role — how authored terminology is made *resolvable*, as a package and/or on a terminology server. For the consumer's view, see [Using terminology](usage.html) and [Implementation notes](implementationnotes.html).
+
+Deployment is the step that turns authored files into something an application can actually reach. It is independent of authoring: the same authored content can be distributed through more than one channel at once.
+
+### This IG as a package
+
+This IG is distributed as the FHIR package:
+
+```text
+hl7.fhir.be.terminology   (canonical: https://hl7belgium.org/profiles/fhir/terminology)
+```
+
+A package is an **immutable, versioned snapshot** of all the CodeSystems, ValueSets and NamingSystems defined here. Consumers add it as a dependency and resolve the content offline, pinned to a version:
+
+```yaml
+# in a consuming IG's sushi-config.yaml
+dependencies:
+  hl7.fhir.be.terminology: 1.0.0
+```
+
+```json
+// or in a plain package.json
+{ "dependencies": { "hl7.fhir.be.terminology": "1.0.0" } }
+```
+
+Each published release is a distinct, frozen artefact — `1.0.0` will always mean exactly the content that was built for `1.0.0`. This is what makes package-based builds reproducible.
+
+### Dependencies of this IG
+
+This IG currently declares no package dependencies of its own (the `dependencies` block in `sushi-config.yaml` is empty). It targets **FHIR R4 (4.0.1)**. If it later relies on external content, those dependencies will be listed here.
+
+Note that depending on a *package* never brings in large external systems such as SNOMED CT or LOINC — those are not shipped in packages and are resolved from a server instead (see [Using terminology](usage.html#the-decision-rule-versioned-vs-unversioned)).
+
+### Distribution via a terminology server
+
+The second deployment channel is a **terminology server**. Here the authored content is *loaded into* a running server (alongside external systems like SNOMED CT and LOINC), which then answers `$expand` / `$validate-code` / `$translate` over the network. This channel is what makes **latest/unversioned** references and external code systems usable.
+
+A terminology server is itself deployed from a **source repository** that holds the server configuration and a manifest of which sources to load — commonly Docker Compose with one profile per environment. The HL7 Belgium server is an example:
+
+- **[github.com/hl7-be/tx-server](https://github.com/hl7-be/tx-server)** — a Docker Compose deployment of a FHIR terminology server, with per-environment profiles and a manifest listing the terminology sources to serve, exposing the terminology operations over `/tx/r4` and `/tx/r5`.
+
+The same pattern is used for local and national servers generally: a server engine plus a curated list of content. Choosing between the package channel and the server channel — for any given consumer — is covered in [Using terminology](usage.html).

--- a/input/pagecontent/design.md
+++ b/input/pagecontent/design.md
@@ -1,0 +1,26 @@
+This page records the **design choices** behind this terminology IG — the rationale for *how* it is structured. For the authoring process and outcomes, see [Authoring](authoring.html); for how to consume the content, see [Using terminology](usage.html).
+
+### FHIR version
+
+The IG targets **FHIR R4 (4.0.1)**. Terminology resources are authored against R4; where R5-only constructs are needed on a resource (for example richer `NamingSystem` metadata), they are carried as extensions rather than by moving the whole IG to R5.
+
+### Canonical URL scheme
+
+All IG-owned resources use canonical URLs under a single base, `https://www.ehealth.fgov.be/standards/fhir/...`, grouped by domain (e.g. `.../medication/...`). A single, stable base makes the content unambiguous to resolve and keeps ownership visible in the identifier itself. Canonical URLs are treated as permanent: they are never reused for different meaning.
+
+### CodeSystem *and* NamingSystem, on purpose
+
+The IG uses both resource types because they answer different questions:
+
+- **CodeSystem** — for systems whose *concepts* are defined here (the `BeCS*`, `MyCareNet*` systems).
+- **NamingSystem** — for systems whose *identity* needs declaring but whose concepts live elsewhere, including **identifier** systems (CNK, SSIN, CBE, NIHDI). These tell implementers which URI to put in `Identifier.system`.
+
+Conflating the two is the most common terminology modelling error; keeping them distinct is a deliberate choice. See [Terminology Considerations](terminology.html) for the underlying distinction.
+
+### Versioning policy
+
+Each resource is independently versioned, and versions are immutable once published (a released package built from a version can never change). Versions are bumped on meaningful content change and never repurposed. This is what lets consumers safely **pin** to a version — see the decision rule in [Using terminology](usage.html#the-decision-rule-versioned-vs-unversioned).
+
+### External systems are referenced, not redefined
+
+SNOMED CT, LOINC, ICD and UCUM are **not** redefined or repackaged here. The IG references them by their canonical URLs and leaves them to be resolved from a terminology server. This keeps the package small and license-clean, and is the reason parts of this IG can only be validated/expanded against a server (see [Using terminology](usage.html)).

--- a/input/pagecontent/implementationnotes.md
+++ b/input/pagecontent/implementationnotes.md
@@ -1,1 +1,49 @@
-a
+This page covers the **consumption** role — how an implementer actually validates codes and expands value sets that use this terminology. For the wider picture (roles, package vs server, the versioning rule), see [Using terminology](usage.html).
+
+Consumption is independent of how the content was authored: you choose your channel based on *what you reference* and *what guarantees you need*, not on how the IG was written.
+
+### Choosing your channel
+
+Use the decision rule from [Using terminology](usage.html#the-decision-rule-versioned-vs-unversioned):
+
+- **Pinned versions of IG-owned content** → depend on the **package** (`hl7.fhir.be.terminology`). Offline, reproducible, no network needed.
+- **Latest/unversioned content, or anything using SNOMED CT / LOINC / ICD / UCUM** → use a **terminology server**.
+- **Most real deployments use both**: the package for IG-owned content, a server for external systems and "latest".
+
+### Validating against a package
+
+If you depend on the package and only use pinned, IG-owned content, the FHIR validator resolves everything offline:
+
+```text
+java -jar validator_cli.jar myresource.json -ig hl7.fhir.be.terminology#1.0.0
+```
+
+The `BeCS*` codes and value sets are checked against exactly the `1.0.0` snapshot.
+
+### Validating against a terminology server
+
+To resolve latest content, expand intensional value sets, or validate codes from external systems, point the validator at a server with `-tx`:
+
+```text
+java -jar validator_cli.jar myresource.json -tx https://<your-terminology-server>/r4
+```
+
+The server may be a **local** server (full control, offline-capable, you load what you need), a **national** server, or the community server `tx.fhir.org`. The HL7 Belgium server (see [Dependencies](dependencies.html)) is an example of a server you can stand up from a source repo.
+
+### Calling the operations directly
+
+Applications consume terminology at runtime by calling the operations against a server endpoint — for example:
+
+```text
+GET  [server]/ValueSet/$expand?url=...BeAllergyIntoleranceCode
+POST [server]/ValueSet/$validate-code        (with the code + value set)
+GET  [server]/CodeSystem/$lookup?system=...&code=...
+```
+
+These are the same operations the validator uses internally; calling them directly is how a production system builds pick-lists, checks user input, and translates codes.
+
+### Reproducibility checklist
+
+- **Pin versions** in CI; rely on the package channel where you can.
+- **Record which terminology server** (and which loaded versions) a build used — a server's answers change as its content is updated.
+- **Expect a server requirement** wherever you reference latest content or external systems; do not assume the package alone is sufficient there.

--- a/input/pagecontent/scope.md
+++ b/input/pagecontent/scope.md
@@ -1,0 +1,26 @@
+### Purpose
+
+This Implementation Guide is a **terminology IG**: it collects the CodeSystems, ValueSets and NamingSystems used across Belgian FHIR profiles in one place, and — just as importantly — explains **how FHIR terminology actually works** so that authors, publishers and implementers share one mental model.
+
+If you are looking for that explanation, start here:
+
+- [Terminology Considerations](terminology.html) — the concepts: the four resource types, the operations, canonical URLs and versions.
+- [Using terminology](usage.html) — the practical guide: package vs server, versioned vs "latest", and how to consume this (or any) terminology package.
+- [Authoring](authoring.html) — how the content here is **authored**, and how to request changes.
+- [Design Choices](design.html) — the **rationale** behind how the content is structured.
+- [Dependencies](dependencies.html) — how it is **deployed/distributed** (package and server).
+- [Implementation notes](implementationnotes.html) — how it is **consumed** (validation, expansion).
+
+### In scope
+
+- Belgian, IG-owned code systems, value sets and identifier naming systems.
+- Guidance on consuming terminology from packages and from local / national / community terminology servers.
+
+### Out of scope
+
+- Defining or redistributing large external code systems (SNOMED CT, LOINC, ICD, UCUM). These are referenced, not redefined, and are always resolved from a terminology server — never from a package.
+- Production governance and ownership of the collected content. As noted on the [home page](index.html), that governance is not yet in place, which is why the current content is **not to be used** as-is.
+
+### Audience
+
+Three audiences map to the three roles described in [Using terminology](usage.html): terminology **authors/owners**, IG **publishers / server operators**, and **implementers** consuming the content. Each page indicates which role it addresses.

--- a/input/pagecontent/terminology.md
+++ b/input/pagecontent/terminology.md
@@ -1,0 +1,48 @@
+This page explains **how terminology works in FHIR** — the resource types, the operations that act on them, and the rules around canonical URLs and versions. It is the conceptual companion to [Using terminology](usage.html), which covers the practical question of *how to consume* the content in this (or any) terminology package.
+
+If you only read one thing: in FHIR, terminology is not "a list of codes in a spreadsheet". It is a small set of *resources* that are *resolved* and *operated on* — either from a package or from a terminology server. Understanding which resource does what, and where it is resolved from, removes most of the confusion.
+
+### The four terminology resources
+
+FHIR separates terminology into four resource types. They are often conflated, so it is worth being precise:
+
+| Resource | Answers the question | Example in this IG |
+|----------|----------------------|--------------------|
+| **CodeSystem** | *What codes exist, and what do they mean?* Defines the concepts, their display text, and their meaning. | `BeCSVaccineCode` |
+| **ValueSet** | *Which codes may be used here?* Selects a subset of one or more CodeSystems for a particular use. | `BeAllergyIntoleranceCode` |
+| **ConceptMap** | *How does a code in system A correspond to a code in system B?* Defines translations between systems/value sets. | — |
+| **NamingSystem** | *What is the canonical identifier (URI/OID) for this system?* Declares the identity of a code system **or** an identifier system. | `be-ns-cnk-codes` |
+
+**CodeSystem vs NamingSystem is the most common confusion.** A CodeSystem *defines concepts*. A NamingSystem *only declares an identity* — it says "this URI and this OID both refer to the same system" and may not contain any concepts at all. Many of the `be-ns-*` resources in this IG are NamingSystems for **identifier** systems (patient/organization identifiers such as CNK, SSIN, CBE), not code systems. They tell you *which URI to put in `Identifier.system`*, not which codes are valid.
+
+### The operations
+
+Terminology resources are not meant to be read by hand — they are *operated on*. The standard FHIR terminology operations are what implementers actually call:
+
+- **`$lookup`** (CodeSystem) — given a code, return its display and properties. *"What does `BeCSVaccineCode#1234` mean?"*
+- **`$validate-code`** (ValueSet or CodeSystem) — is this code valid here? *"Is this code a member of this value set?"*
+- **`$expand`** (ValueSet) — list the concrete codes a value set resolves to, for pick-lists and validation.
+- **`$translate`** (ConceptMap) — map a code from one system to another.
+- **`$subsumes`** (CodeSystem) — does code A contain code B in its hierarchy? (mainly SNOMED CT / hierarchical systems).
+
+These run on a **terminology server**. The IG publisher and the FHIR validator call them for you behind the scenes when they check that the codes in examples and profiles are valid.
+
+### Canonical URLs and versions
+
+Every CodeSystem, ValueSet and ConceptMap has a **canonical URL** (its `url`) — a globally unique, stable identifier. In this IG these live under `https://www.ehealth.fgov.be/standards/fhir/...`. A reference such as `BeCSVaccineCode` is ultimately a reference to that canonical URL.
+
+A reference may be **versioned** or **unversioned**:
+
+- **Versioned** — `…/CodeSystem/BeCSVaccineCode|1.1.0`. Pins one exact version.
+- **Unversioned** — `…/CodeSystem/BeCSVaccineCode`. Means "the applicable / latest version", resolved at the time of use.
+
+This versioned-vs-unversioned distinction is the single most important thing to get right when consuming terminology, because it determines **whether a package is enough or whether you need a server**. That is covered in detail on [Using terminology](usage.html).
+
+### Where it comes from: package or server
+
+A FHIR resource that uses a code does not embed the whole CodeSystem. The code system has to be *resolved* from somewhere:
+
+- from a **package** (an immutable, versioned snapshot — e.g. this IG distributed as `hl7.fhir.be.terminology`), or
+- from a **terminology server** (a live service that holds current and historical versions and can run the operations above).
+
+Small, IG-owned code systems travel happily in packages. Large external systems — **SNOMED CT, LOINC, ICD-10/11, UCUM** — never do; they are too large and/or licensed, and always require a server. See [Using terminology](usage.html) for the full decision logic.

--- a/input/pagecontent/usage.md
+++ b/input/pagecontent/usage.md
@@ -1,0 +1,84 @@
+This page explains **how to use this terminology** — and, by extension, any FHIR terminology package. It assumes you already understand the basic resource types and operations; if not, read [Terminology Considerations](terminology.html) first.
+
+There are two things to get straight before anything else:
+
+1. **Three different roles** are involved in terminology, and they have different concerns: **authoring**, **deployment/distribution**, and **consumption**.
+2. **Two delivery channels** exist for the content: a **package** (a frozen snapshot) and a **terminology server** (a live service). Which one you need depends on whether you reference content *by version* or *by "latest"*.
+
+### Three roles, three concerns
+
+The same CodeSystem looks very different depending on which role you are in. Keeping these separate avoids most arguments:
+
+| Role | Who | What they care about | In this IG |
+|------|-----|----------------------|------------|
+| **Authoring** | Terminology owner / IG editor | Correctness, meaning, governance, ownership, canonical URLs, versioning policy — and how to **request changes** (including upstream requests for new SNOMED codes, translations, etc.) | The FSH sources here that define `BeCS*` CodeSystems, ValueSets and `be-ns-*` NamingSystems. See [Authoring](authoring.html). |
+| **Deployment / distribution** | Publisher / server operator | Making the authored content *resolvable* — building the package, loading a terminology server, versioning the releases | This IG published as the package `hl7.fhir.be.terminology`, and/or loaded into a terminology server. See [Dependencies](dependencies.html). |
+| **Consumption** | Implementer / validator | Validating codes, expanding value sets, translating — reliably and reproducibly | Pointing your validator or client at a package and/or a server. See [Implementation notes](implementationnotes.html). |
+
+A crucial consequence: **authoring is not the same as deployment.** Defining a correct CodeSystem in this IG does *not* automatically make it available to a running application — it must first be *deployed*, either inside a package you depend on or onto a terminology server you can reach. Likewise, **consumption choices are independent of authoring**: the same authored content can be consumed from a package by one team and from a national server by another.
+
+### Two delivery channels: package vs server
+
+**A package** (e.g. `hl7.fhir.be.terminology#1.0.0`) is an **immutable, versioned snapshot**. It ships *one specific version* of each CodeSystem and ValueSet it contains. Packages are downloaded and resolved offline; they are reproducible and need no network at validation time. But:
+
+- a package only ever contains the version it was built with — it is a frozen point in time, and
+- a package cannot hold large external systems (SNOMED CT, LOINC, …), so any value set that draws on those still cannot be *expanded* from the package alone.
+
+**A terminology server** (local, national, or the community server `tx.fhir.org`) is a **live service**. It holds current and historical versions, can `$expand` / `$validate-code` / `$translate` on demand, and can serve large external systems. It needs to be reachable and is only as up-to-date and correct as whatever has been loaded into it.
+
+### The decision rule: versioned vs unversioned
+
+This is the rule that answers your question. It follows directly from "a package is a frozen snapshot":
+
+| You reference… | A package is enough | A server is required |
+|----------------|:---:|:---:|
+| A **specific version** (`…\|1.1.0`) that is *inside* a package you depend on | ✅ | (optional) |
+| A **specific version** that is *not* in any package you have | — | ✅ (a server holding that version) |
+| The **latest / unversioned** content (`…` with no `\|version`) | ❌ not reliably | ✅ |
+| Anything built on **SNOMED CT / LOINC / ICD / UCUM** | ❌ | ✅ always |
+
+**Why "latest" needs a server.** A package is immutable. If you reference content *without a version*, you are asking for "whatever is current". A package can only ever give you the snapshot it happened to be built with — that may already be out of date, and nothing in the package will tell you so. To resolve "the latest as centrally maintained" *reliably*, you need a live terminology server that maintains the current version. So:
+
+> **Pinned version → a package (or a server) works. Latest/unversioned → you need a server.**
+
+Two refinements worth remembering:
+
+- **Some systems always need a server, version or not.** SNOMED CT, LOINC, ICD-10/11 and similar are never shipped in packages (size and licensing). Any artefact that uses them needs a terminology server regardless of how it is referenced.
+- **Intensional expansion needs the code system content.** A value set defined by a *filter* ("all descendants of X") can live in a package, but actually *expanding* it requires a server that holds the full underlying CodeSystem.
+
+**Practical recommendation:** for reproducible builds and CI, **pin versions and depend on packages** where you can; reach for a server when you need the latest content, when you use SNOMED CT/LOINC/etc., or when you need live `$expand`/`$translate`. Most real deployments use **both**: packages for the IG-owned content, a server for the external systems and for "latest".
+
+### Using *this* package
+
+**As a dependency** (the package channel). Add it to the consuming IG's `sushi-config.yaml`:
+
+```yaml
+dependencies:
+  hl7.fhir.be.terminology: 1.0.0
+```
+
+or to a plain `package.json`:
+
+```json
+{ "dependencies": { "hl7.fhir.be.terminology": "1.0.0" } }
+```
+
+The IG publisher and the FHIR validator will then resolve the `BeCS*` CodeSystems and ValueSets from the package — offline, pinned to `1.0.0`.
+
+**Via a terminology server** (the server channel). Point your validator or client at a server that has this content loaded — a **local** server, a **national** server, or the community server. With the official FHIR validator:
+
+```text
+java -jar validator_cli.jar myresource.json -tx https://<your-terminology-server>/r4
+```
+
+Use the server channel when you need the latest content, when your artefacts touch SNOMED CT/LOINC, or when you need `$expand`/`$translate` at runtime. See [Implementation notes](implementationnotes.html) for details.
+
+### Where the terminology server comes from
+
+A terminology server is itself *deployed* from a source repository — typically a repo that contains the server configuration and a manifest of which terminology sources (packages, SNOMED CT, LOINC, …) to load, often as Docker Compose with one profile per environment (local / national / EU / full).
+
+The HL7 Belgium terminology server is an example of such a repo:
+
+- **[github.com/hl7-be/tx-server](https://github.com/hl7-be/tx-server)** — Docker Compose deployment of a FHIR terminology server, with profiles for Belgium and others, where a `library.yml`-style manifest lists the terminology sources to load and the server exposes `$expand` / `$validate-code` / `$translate` over `/tx/r4` and `/tx/r5`.
+
+The pattern generalises: a national or organisation-specific terminology server is usually one of these "server source repos", combining a server engine with a curated list of content to serve. This is the **deployment** role from the table above — it is what turns authored terminology into a reachable service.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -149,6 +149,10 @@ pages:
     title: Logical models
   terminology.md:
     title: Terminology Considerations
+  authoring.md:
+    title: Authoring
+  usage.md:
+    title: Using terminology
   profilemapping.md:
     title: Mapping to profiles
   examples.md:
@@ -209,6 +213,8 @@ menu:
 #      - Scenarios
     Logical models: logicals.html
     Terminology considerations: terminology.html
+    Authoring: authoring.html
+    Using terminology: usage.html
 
 
   Implementation:


### PR DESCRIPTION
Explain how FHIR terminology works across the authoring, deployment, and consumption roles:

- terminology.md: concepts (resource types, operations, canonical URLs/versions)
- authoring.md (new): authoring outcomes + requesting changes via ticket, including upstream requests (SNOMED, LOINC, translations)
- usage.md (new): package vs server, versioned-vs-latest decision rule, server source repos
- design.md: design rationale
- dependencies.md: package distribution + dependency snippet
- implementationnotes.md: consumption / validator config
- scope.md: framing and navigation

Register authoring.md and usage.md in sushi-config pages and menu.